### PR TITLE
Fix URL for nimlangserver releases

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -22,8 +22,8 @@ if any new server settings are added or old ones removed.
 """
 SESSION_NAME = "nimlangserver"
 SETTINGS_FILENAME = "LSP-nimlangserver.sublime-settings"
-# https://github.com/nim-lang/langserver/releases/download/v1.2.0/nimlangserver-1.2.0-windows-amd64.zip
-URL = "https://github.com/nim-lang/langserver/releases/download/v{tag}/nimlangserver-{tag}-{platform}-{arch}.{archive_type}"
+# https://github.com/nim-lang/langserver/releases/download/v1.10.0/nimlangserver-windows-amd64.zip
+URL = "https://github.com/nim-lang/langserver/releases/download/v{tag}/nimlangserver-{platform}-{arch}.{archive_type}"
 
 
 def arch() -> str:


### PR DESCRIPTION
The URL for the nimlangserver release has changed and does no longer include the `tag` in the name. This can be verified by looking at the [assets](https://github.com/nim-lang/langserver/releases/tag/v1.10.0) for the release we're [currently targeting](https://github.com/sublimelsp/LSP-nimlangserver/blob/9b7cc4cbd72e73533b222883b8d2e256bb7a2a50/plugin.py#L17).

