### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,18 +1,20 @@
-import os
-import shutil
-import stat
-import subprocess
-import urllib.request
+from __future__ import annotations
 
-import sublime
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import register_plugin
 from LSP.plugin import unregister_plugin
 from LSP.plugin.core.types import ClientConfig
-from LSP.plugin.core.typing import List, Optional, Tuple
+from LSP.plugin.core.typing import List
+from LSP.plugin.core.typing import Optional
+from LSP.plugin.core.typing import Tuple
 from LSP.plugin.core.views import MarkdownLangMap
 from LSP.plugin.core.workspace import WorkspaceFolder
-
+import os
+import shutil
+import stat
+import sublime
+import subprocess
+import urllib.request
 
 VERSION = (1, 10, 0)
 """

--- a/plugin.py
+++ b/plugin.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
+import os
+import shutil
+import stat
+import subprocess
+import urllib.request
+
+import sublime
 from LSP.plugin import AbstractPlugin
 from LSP.plugin import register_plugin
 from LSP.plugin import unregister_plugin
 from LSP.plugin.core.types import ClientConfig
-from LSP.plugin.core.typing import List
-from LSP.plugin.core.typing import Optional
-from LSP.plugin.core.typing import Tuple
 from LSP.plugin.core.views import MarkdownLangMap
 from LSP.plugin.core.workspace import WorkspaceFolder
-import os
-import shutil
-import stat
-import sublime
-import subprocess
-import urllib.request
 
 VERSION = (1, 10, 0)
 """
@@ -75,7 +73,7 @@ class NimlangserverPlugin(AbstractPlugin):
         return SESSION_NAME
 
     @classmethod
-    def markdown_language_id_to_st_syntax_map(cls) -> Optional[MarkdownLangMap]:
+    def markdown_language_id_to_st_syntax_map(cls) -> MarkdownLangMap | None:
         path = sublime.find_syntax_by_name("Nim")[0].path
         return {"nim": (("nim",), (path[9 : path.rfind(".")],))}
 
@@ -85,7 +83,7 @@ class NimlangserverPlugin(AbstractPlugin):
         return os.path.join(cls.storage_path(), __package__ or "")
 
     @classmethod
-    def get_server_version(cls, path: str) -> Tuple[int, int, int]:
+    def get_server_version(cls, path: str) -> tuple[int, int, int]:
         with subprocess.Popen([path, "-v"], stdout=subprocess.PIPE, shell=os.name == "nt") as process:
             stdout, _ = process.communicate(timeout=5)
 
@@ -96,7 +94,7 @@ class NimlangserverPlugin(AbstractPlugin):
                 return (0, 0, 0)
 
     @classmethod
-    def managed_server_path(cls) -> Optional[str]:
+    def managed_server_path(cls) -> str | None:
         binary_name = "nimlangserver.exe" if sublime.platform() == "windows" else "nimlangserver"
         path = os.path.join(cls.basedir(), binary_name)
         if os.path.exists(path):
@@ -104,14 +102,14 @@ class NimlangserverPlugin(AbstractPlugin):
         return None
 
     @classmethod
-    def system_server_path(cls, binary: str) -> Optional[str]:
+    def system_server_path(cls, binary: str) -> str | None:
         binary_path = shutil.which(binary) or binary
         if not os.path.isfile(binary_path):
             return None
         return binary_path
 
     @classmethod
-    def server_path(cls) -> Optional[str]:
+    def server_path(cls) -> str | None:
         """The command to start the server."""
         binary_setting = get_settings().get("binary")
         if binary_setting and isinstance(binary_setting, str):
@@ -173,9 +171,9 @@ class NimlangserverPlugin(AbstractPlugin):
         cls,
         window: sublime.Window,
         initiating_view: sublime.View,
-        workspace_folders: List[WorkspaceFolder],
+        workspace_folders: list[WorkspaceFolder],
         configuration: ClientConfig,
-    ) -> Optional[str]:
+    ) -> str | None:
         binary_setting = get_settings().get("binary")
         if binary_setting and isinstance(binary_setting, str):
             path = cls.system_server_path(binary_setting)
@@ -190,9 +188,9 @@ class NimlangserverPlugin(AbstractPlugin):
         cls,
         window: sublime.Window,
         initiating_view: sublime.View,
-        workspace_folders: List[WorkspaceFolder],
+        workspace_folders: list[WorkspaceFolder],
         configuration: ClientConfig,
-    ) -> Optional[str]:
+    ) -> str | None:
         server_path = cls.server_path()
         if not server_path:
             raise ValueError("nimlangserver is currently not installed.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
+[tool.pyright]
+pythonVersion = "3.8"
+
 [tool.ruff]
-line-length = 120
+line-length = 110
 target-version = "py38"
 
 [tool.ruff.lint]
@@ -8,14 +11,8 @@ preview = true
 select = ["F401", "I"]
 
 [tool.ruff.lint.isort]
-case-sensitive = false
+case-sensitive = true
+combine-as-imports = true
 force-single-line = true
-from-first = true
-no-sections = true
 order-by-type = false
 required-imports = ["from __future__ import annotations"]
-
-
-[tool.pyright]
-pythonVersion = "3.8"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,21 @@
 [tool.ruff]
-line-length = 110
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]
+
+
+[tool.pyright]
+pythonVersion = "3.8"
+


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)