### PR TITLE
feat: add nim.formatter setting with nph as default

### DIFF
--- a/LSP-nimlangserver.sublime-settings
+++ b/LSP-nimlangserver.sublime-settings
@@ -51,6 +51,8 @@
 		"nim.maxNimsuggestProcesses": 0,
 		// The timeout in ms after which an idle nimsuggest will be stopped. If not specified the default is 120 seconds.
 		"nim.nimsuggestIdleTimeout": 120000,
+		// The nim formatter in use, either "nph" or "nimpretty".
+		"nim.formatter": "nph"
 	},
 	"selector": "source.nim",
 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -161,6 +161,15 @@
                       "default": 120000,
                       "description": "The timeout in ms after which an idle nimsuggest will be stopped. If not specified the default is 120 seconds."
                     },
+                    "nim.formatter": {
+                      "type": "string",
+                      "default": "nph",
+                      "enum": [
+                        "nph",
+                        "nimpretty",
+                      ],
+                      "description": "The nim formatter in use, either `nph` or `nimpretty`. Defaults to nph."
+                    },
                   }
                 }
               }


### PR DESCRIPTION
Hey,

there is an outstanding PR I've contributed to the nim langserver project. It allows the use of `nimpretty` instead of `nph` as a formatter: https://github.com/nim-lang/langserver/pull/405

This PR is just the plugin configuration expansion for it.

Please merge when available.